### PR TITLE
megamenu: display on hover for not-tiny screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -76,7 +76,7 @@ li:empty{
 	text-decoration: none;
 }
 
-@media (max-width: 768px){ /* tiny breakpoint and below */
+@media (max-width: 768px){ /* tiny screens (-xs) */
 	.site-title{
 		font-size: 2.75em;
 	}
@@ -112,7 +112,7 @@ li:empty{
 	margin-right: 0;
 }
 
-@media (max-width: 992px){ /* medium to large breakpoint */
+@media (max-width: 992px){ /* small screens (-xs and -sm) */
 	.site-nav.navbar-default .navbar-text.navbar-right.translate-button{
 		float: none!important;
 	}
@@ -136,19 +136,19 @@ li:empty{
 	height: 317px;
 }
 
-@media only screen and (max-width: 1200px){ /* medium breakpoint and smaller */
+@media only screen and (max-width: 1200px){ /* not-large screens (-xs, -sm, -md) */
 	.site-billboard > #slider{
 		height: 247px;
 	}
 }
 
-@media only screen and (max-width: 992px){ /* small breakpoint and smaller */
+@media only screen and (max-width: 992px){ /* small screens (-xs, -sm) */
 	.site-billboard > #slider{
 		height: 185px;
 	}
 }
 
-@media only screen and (max-width: 768px){ /* tiny breakpoint and smaller */
+@media only screen and (max-width: 768px){ /* tiny screens (-xs) */
 	.site-billboard > #slider{
 		height: auto;
 	}
@@ -178,7 +178,7 @@ li:empty{
 	padding-left: 5px;
 }
 
-@media only screen and (max-width: 768px){ /* tiny breakpoint and smaller */
+@media only screen and (max-width: 768px){ /* tiny screens (-xs) */
 	.nivo-title{
 		font-size: 1.25em;
 	}
@@ -197,7 +197,7 @@ li:empty{
 	margin-top: 10px;
 }
 
-@media (max-width: 768px){ /* tiny breakpoint and smaller */
+@media (max-width: 768px){ /* tiny screens (-xs) */
 	.page-header > .pull-right{
 		float: none!important;
 	}
@@ -258,7 +258,7 @@ li:empty{
 	color: #ccc;
 }
 
-@media (max-width: 768px){ /* tiny breakpoint and smaller */
+@media (max-width: 768px){ /* tiny screens (-xs) */
 	.site-sub-footer > .container > .row > .text-right{
 		margin-top: 1em;
 		text-align: left;
@@ -367,7 +367,7 @@ li:empty{
 	padding: 1.25em 0;
 }
 
-@media only screen and (max-width: 500px){ /* arbitrary breakpoint */
+@media only screen and (max-width: 500px){ /* arbitrary breakpoint - very tiny screens */
 	.staff img, .news img{
 		width: auto;
 		margin: 1em auto;
@@ -673,6 +673,13 @@ h1 a[href$='.pptx'], h2 a[href$='.pptx'], h3 a[href$='.pptx']{
 .navbar-default .navbar-nav>.open>a:hover,
 .navbar-default .navbar-nav>.open>a:focus {
 	background-color: #fdfbf5;
+}
+
+@media (min-width: 768px){ /* not-tiny screens (-sm, -md, -lg) */
+	/* Show Yamm!3 megamenu on hover */
+	.yamm ul.nav li.dropdown:hover > ul.dropdown-menu {
+	    display: block;    
+	}
 }
 
 /* .NET fixers ----------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
For only screens above the hide navigation breakpoint (not-tiny, 768px
or higher), show the megamenu on mouse hover.

Also, standardize naming for media breakpoints in comments.